### PR TITLE
Fix float64 and lint

### DIFF
--- a/node.go
+++ b/node.go
@@ -127,7 +127,7 @@ func parseValue(x interface{}, top *Node, level int) {
 		n := &Node{Data: v, Type: TextNode, level: level}
 		addNode(n)
 	case float64:
-		s := strconv.FormatFloat(v, 'f', -1, 32)
+		s := strconv.FormatFloat(v, 'f', -1, 64)
 		n := &Node{Data: s, Type: TextNode, level: level}
 		addNode(n)
 	case bool:

--- a/node_test.go
+++ b/node_test.go
@@ -22,22 +22,22 @@ func TestParseJsonNumberArray(t *testing.T) {
 	// ...
 	// <element>6</element>
 	if e, g := 6, len(doc.ChildNodes()); e != g {
-		t.Fatalf("excepted %d but got %d", e, g)
+		t.Fatalf("excepted %v but got %v", e, g)
 	}
 	var v []string
 	for _, n := range doc.ChildNodes() {
 		v = append(v, n.InnerText())
 	}
 	if got, expected := strings.Join(v, ","), "1,2,3,4,5,6"; got != expected {
-		t.Fatalf("got %s but expected %s", got, expected)
+		t.Fatalf("got %v but expected %v", got, expected)
 	}
 }
 
 func TestParseJsonObject(t *testing.T) {
 	s := `{
 		"name":"John",
-		"age":31, 
-		"city":"New York" 
+		"age":31,
+		"city":"New York"
 	}`
 	doc, err := parseString(s)
 	if err != nil {
@@ -60,7 +60,7 @@ func TestParseJsonObject(t *testing.T) {
 	}
 	for _, v := range expected {
 		if e, g := v.value, m[v.name]; e != g {
-			t.Fatalf("expected %s=%s,but %s=%s", v.name, e, v.name, g)
+			t.Fatalf("expected %v=%v,but %v=%v", v.name, e, v.name, g)
 		}
 	}
 }
@@ -70,7 +70,6 @@ func TestParseJsonObjectArray(t *testing.T) {
 		{ "name":"Ford", "models":[ "Fiesta", "Focus", "Mustang" ] },
 		{ "name":"BMW", "models":[ "320", "X3", "X5" ] },
         { "name":"Fiat", "models":[ "500", "Panda" ] }
-      
 	]`
 	doc, err := parseString(s)
 	if err != nil {
@@ -96,7 +95,7 @@ func TestParseJsonObjectArray(t *testing.T) {
 	....
 	*/
 	if e, g := 3, len(doc.ChildNodes()); e != g {
-		t.Fatalf("expected %d, but %d", e, g)
+		t.Fatalf("expected %v, but %v", e, g)
 	}
 	m := make(map[string][]string)
 	for _, n := range doc.ChildNodes() {
@@ -128,7 +127,7 @@ func TestParseJsonObjectArray(t *testing.T) {
 	}
 	for _, v := range expected {
 		if e, g := v.value, strings.Join(m[v.name], ","); e != g {
-			t.Fatalf("expected %s=%s,but %s=%s", v.name, e, v.name, g)
+			t.Fatalf("expected %v=%v,but %v=%v", v.name, e, v.name, g)
 		}
 	}
 }
@@ -155,10 +154,24 @@ func TestParseJson(t *testing.T) {
 		t.Fatal("next sibling shoud be nil")
 	}
 	if e, g := "John", n.InnerText(); e != g {
-		t.Fatalf("expected %s but %s", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	cars := doc.SelectElement("cars")
 	if e, g := 3, len(cars.ChildNodes()); e != g {
-		t.Fatalf("expected %d but %d", e, g)
+		t.Fatalf("expected %v but %v", e, g)
+	}
+}
+
+func TestLargeFloat(t *testing.T) {
+	s := `{
+		"large_number": 365823929453
+	 }`
+	doc, err := parseString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := doc.SelectElement("large_number")
+	if n.InnerText() != "365823929453" {
+		t.Fatalf("expected %v but %v", "365823929453", n.InnerText())
 	}
 }

--- a/query_test.go
+++ b/query_test.go
@@ -43,20 +43,20 @@ func TestNavigator(t *testing.T) {
 	}
 	// Move to first child(age).
 	if e, g := true, nav.MoveToChild(); e != g {
-		t.Fatalf("expected %s but %s", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	if e, g := "age", nav.Current().Data; e != g {
-		t.Fatalf("expected %s but %s", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	if e, g := "30", nav.Value(); e != g {
-		t.Fatalf("expected %s but %s", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	// Move to next sibling node(cars).
 	if e, g := true, nav.MoveToNext(); e != g {
-		t.Fatalf("expected %b but %b", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	if e, g := "cars", nav.Current().Data; e != g {
-		t.Fatalf("expected %s but %s", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	m := make(map[string][]string)
 	// Move to cars child node.
@@ -64,25 +64,25 @@ func TestNavigator(t *testing.T) {
 	for ok := nav.MoveToChild(); ok; ok = nav.MoveToNext() {
 		// Move to <element> node.
 		// <element><models>...</models><name>Ford</name></element>
-		cur_1 := nav.Copy()
+		cur1 := nav.Copy()
 		var name string
 		var models []string
 		// name || models
 		for ok := nav.MoveToChild(); ok; ok = nav.MoveToNext() {
-			cur_2 := nav.Copy()
+			cur2 := nav.Copy()
 			n := nav.Current()
 			if n.Data == "name" {
 				name = n.InnerText()
 			} else {
 				for ok := nav.MoveToChild(); ok; ok = nav.MoveToNext() {
-					cur_3 := nav.Copy()
+					cur3 := nav.Copy()
 					models = append(models, nav.Value())
-					nav.MoveTo(cur_3)
+					nav.MoveTo(cur3)
 				}
 			}
-			nav.MoveTo(cur_2)
+			nav.MoveTo(cur2)
 		}
-		nav.MoveTo(cur_1)
+		nav.MoveTo(cur1)
 		m[name] = models
 	}
 	expected := []struct {
@@ -94,23 +94,23 @@ func TestNavigator(t *testing.T) {
 	}
 	for _, v := range expected {
 		if e, g := v.value, strings.Join(m[v.name], ","); e != g {
-			t.Fatalf("expected %s=%s,but %s=%s", v.name, e, v.name, g)
+			t.Fatalf("expected %v=%v,but %v=%v", v.name, e, v.name, g)
 		}
 	}
 	nav.MoveTo(cur)
 	// move to name.
 	if e, g := true, nav.MoveToNext(); e != g {
-		t.Fatalf("expected %b but %b", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	// move to cars
 	nav.MoveToPrevious()
 	if e, g := "cars", nav.Current().Data; e != g {
-		t.Fatalf("expected %s but %s", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	// move to age.
 	nav.MoveToFirst()
 	if e, g := "age", nav.Current().Data; e != g {
-		t.Fatalf("expected %s but %s", e, g)
+		t.Fatalf("expected %v but %v", e, g)
 	}
 	nav.MoveToParent()
 	if g := nav.Current().Type; g != DocumentNode {


### PR DESCRIPTION
Fix `strconv.FormatFloat(v, 'f', -1, 64)`

The reason is that in JSON the number is a float64 type, if we just format it as `32`, it will trim some of the bits. For example,

```
365823929453 => 365823920000
```

Also, fixed some of the go lint problems