### PR TITLE
fix: Propagate node name for nested arrays

### DIFF
--- a/node.go
+++ b/node.go
@@ -164,7 +164,7 @@ func parseValue(x interface{}, top *Node, level int) {
 	case []interface{}:
 		// JSON array
 		for _, vv := range v {
-			n := &Node{Type: ElementNode, level: level, value: vv}
+			n := &Node{Data: top.Data, Type: ElementNode, level: level, value: vv}
 			addNode(n)
 			parseValue(vv, n, level+1)
 		}

--- a/node_test.go
+++ b/node_test.go
@@ -133,3 +133,25 @@ func TestLargeFloat(t *testing.T) {
 		t.Fatalf("expected %v but %v", "365823929453", n.InnerText())
 	}
 }
+
+func TestNestedArray(t *testing.T) {
+	s := `{
+		"values": [
+			[
+				1,
+				2,
+				3
+			]
+		]
+	 }`
+	doc, err := parseString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `<?xml version="1.0" encoding="utf-8"?><root><values><values>1</values><values>2</values><values>3</values></values></root>`
+	xml := doc.OutputXML()
+	if xml != expected {
+		t.Fatalf("expected %q but got %q", expected, xml)
+	}
+}


### PR DESCRIPTION
When parsing nested arrays such as

```json
{
	"values": [
		[
			1,
			2,
			3
		]
	]
 }
```

the XML equivalent looks like

```xml
<?xml version="1.0" encoding="utf-8"?>
<root>
	<values>
		<>1</>
		<>2</>
		<>3</>
	</values>
</root>
```

with a missing element name for the inner (an all additional nestings) array elements.

This PR propagates the node name down the processing stream to also name the inner elements according to the parent. For the example above this results in 

```xml
<?xml version="1.0" encoding="utf-8"?>
<root>
	<values>
		<values>1</values>
		<values>2</values>
		<values>3</values>
	</values>
</root>
```
