### PR TITLE
Revert "fix: Propagate node name for nested arrays" as it breaks backward compatibility

### DIFF
--- a/node.go
+++ b/node.go
@@ -164,7 +164,7 @@ func parseValue(x interface{}, top *Node, level int) {
 	case []interface{}:
 		// JSON array
 		for _, vv := range v {
-			n := &Node{Data: top.Data, Type: ElementNode, level: level, value: vv}
+			n := &Node{Type: ElementNode, level: level, value: vv}
 			addNode(n)
 			parseValue(vv, n, level+1)
 		}

--- a/node_test.go
+++ b/node_test.go
@@ -133,25 +133,3 @@ func TestLargeFloat(t *testing.T) {
 		t.Fatalf("expected %v but %v", "365823929453", n.InnerText())
 	}
 }
-
-func TestNestedArray(t *testing.T) {
-	s := `{
-		"values": [
-			[
-				1,
-				2,
-				3
-			]
-		]
-	 }`
-	doc, err := parseString(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := `<?xml version="1.0" encoding="utf-8"?><root><values><values>1</values><values>2</values><values>3</values></values></root>`
-	xml := doc.OutputXML()
-	if xml != expected {
-		t.Fatalf("expected %q but got %q", expected, xml)
-	}
-}


### PR DESCRIPTION
This reverts commit 5dc78031b1e01ea46098b6717d6fed5abcea7994 as the fix introduced another naming element changing the resulting node paths. We see a lot of breakage in backward compatibility in [Telegraf](https://github.com/influxdata/telegraf/pull/15004)...